### PR TITLE
Support window.location.origin if BASE_URL is not set

### DIFF
--- a/lib/citadel.ts
+++ b/lib/citadel.ts
@@ -1,5 +1,5 @@
 import { Citadel } from "@runcitadel/sdk/browser/index.browser.js";
 
-const citadel = new Citadel(process.env.BASE_URL);
+const citadel = new Citadel(process.env.BASE_URL || window.location.origin);
 
 export default citadel;


### PR DESCRIPTION
When this is launched, the base URL may be different depending on if the user accesses over Tor, citadel.local, or locally using the IP.
By not depending on the base URL from process.env, this is fixed.