### PR TITLE
Faster docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY . .
 RUN yarn
 
-FROM node:alpine AS builder
+FROM amd64/node:alpine AS builder
 COPY --from=deps /app /app
 WORKDIR /app
 RUN yarn build
@@ -25,7 +25,7 @@ RUN adduser -S nextjs -u 1001
 COPY --from=builder /app/next.config.js ./
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
-COPY --from=builder /app/node_modules ./node_modules
+COPY --from=deps /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
 
 USER nextjs


### PR DESCRIPTION
By running the builds natively on the host instead of through qemu, we can (hopefully) reduce the build time by a lot.